### PR TITLE
changed build script so it will work with version 1.10+ as well as 1.7

### DIFF
--- a/build/ci.go
+++ b/build/ci.go
@@ -177,18 +177,25 @@ func doInstall(cmdline []string) {
 
 	// Check Go version. People regularly open issues about compilation
 	// failure with outdated Go. This should save them the trouble.
-
-	minorGoVersion, err := strconv.Atoi(strings.Split(runtime.Version(), ".")[1])
+	majorGoVersion, err := strconv.Atoi(strings.Split(strings.Split(runtime.Version(), "go")[1], ".")[0])
 	if err != nil {
 		log.Println("Version returned does not correspond with supported 1.7+ version.")
 		log.Println("You are running version: ", runtime.Version())
 		os.Exit(1)
 	}
-	if minorGoVersion < 7 && !strings.Contains(runtime.Version(), "devel") {
-		log.Println("You have Go version", runtime.Version())
-		log.Println("go-wtc requires at least Go version 1.7 and cannot")
-		log.Println("be compiled with an earlier version. Please upgrade your Go installation.")
-		os.Exit(1)
+	if majorGoVersion < 2 {
+		minorGoVersion, err := strconv.Atoi(strings.Split(runtime.Version(), ".")[1])
+		if err != nil {
+			log.Println("Version returned does not correspond with supported 1.7+ version.")
+			log.Println("You are running version: ", runtime.Version())
+			os.Exit(1)
+		}
+		if minorGoVersion < 7 && !strings.Contains(runtime.Version(), "devel") {
+			log.Println("You have Go version", runtime.Version())
+			log.Println("go-wtc requires at least Go version 1.7 and cannot")
+			log.Println("be compiled with an earlier version. Please upgrade your Go installation.")
+			os.Exit(1)
+		}
 	}
 	// Compile packages given as arguments, or everything if there are no arguments.
 	packages := []string{"./..."}

--- a/build/ci.go
+++ b/build/ci.go
@@ -54,6 +54,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -176,7 +177,14 @@ func doInstall(cmdline []string) {
 
 	// Check Go version. People regularly open issues about compilation
 	// failure with outdated Go. This should save them the trouble.
-	if runtime.Version() < "go1.7" && !strings.Contains(runtime.Version(), "devel") {
+
+	minorGoVersion, err := strconv.Atoi(strings.Split(runtime.Version(), ".")[1])
+	if err != nil {
+		log.Println("Version returned does not correspond with supported 1.7+ version.")
+		log.Println("You are running version: ", runtime.Version())
+		os.Exit(1)
+	}
+	if minorGoVersion < 7 && !strings.Contains(runtime.Version(), "devel") {
 		log.Println("You have Go version", runtime.Version())
 		log.Println("go-wtc requires at least Go version 1.7 and cannot")
 		log.Println("be compiled with an earlier version. Please upgrade your Go installation.")


### PR DESCRIPTION
small tweak to allow users to use any version of Go from 1.7 and above (including the 1.10+ version) which currently causes problems. see #3 

I do realize, If we ever get Go version 2.0 this might have problems, but I do not think its a problem we will have for many years.